### PR TITLE
Fix water-level button text

### DIFF
--- a/Proyecto Final/Programa/Codigo final/Codigo final esp/src/main.cpp
+++ b/Proyecto Final/Programa/Codigo final/Codigo final esp/src/main.cpp
@@ -317,7 +317,7 @@ String ImprimirEnWeb(const String &var)
 
   // Devuelve un texto (Activar llenado)
   if (var == "BTNL")
-      return "Encender calentamiento manual";
+      return "Encender llenado manual";
 
   // Devuelve un texto (Activar calentamiento automatico)
   if (var == "STTA")


### PR DESCRIPTION
## Summary
- correct the BTNL button text to indicate manual water-level filling

## Testing
- `pio run` *(fails: `pio` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840670076708328ac565708eaaddda8