### PR TITLE
Fix typo in serial read comment

### DIFF
--- a/Proyecto Final/Programa/Codigo final/Codigo final esp/src/main.cpp
+++ b/Proyecto Final/Programa/Codigo final/Codigo final esp/src/main.cpp
@@ -368,7 +368,7 @@ void Leer_Serial()
   uint8_t largoMensaje;
   char comando;
 
-  entradaSerial = Serial.readString();   // iguala el string del serial a un string imput
+  entradaSerial = Serial.readString();   // iguala el string del serial a un string input
   largoMensaje = entradaSerial.length(); // saca el largo del string
   comando = entradaSerial.charAt(0);       // toma el char de comando (el primer char usualmente una letra)
   memset(Datos, 0, 22);


### PR DESCRIPTION
## Summary
- correct a comment describing serial input reading

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840670058288328b51ebe382cd23ee1